### PR TITLE
Fix typo in file name that crashes CytoTalk

### DIFF
--- a/R/compute_mutual_information.R
+++ b/R/compute_mutual_information.R
@@ -85,10 +85,10 @@ compute_mutual_information_type <- function(dir_out, type) {
 compute_mutual_information <- function(dir_out, cores=NULL) {
     # register cores for parallel computation
     if (is.null(cores)) {
-        message("No number of cores were specified - using all possible.")
+        message("No number of cores were specified for MI - using all possible.")
         cores <- max(1, parallel::detectCores() - 2)
     } else {
-        message(sprintf("Computing mutual information with %s cores"), cores)
+        message(sprintf("Computing MI with %s cores", cores))
         cores <- max(1, cores)
     }
     doParallel::registerDoParallel(cores = cores)

--- a/R/compute_mutual_information.R
+++ b/R/compute_mutual_information.R
@@ -85,8 +85,10 @@ compute_mutual_information_type <- function(dir_out, type) {
 compute_mutual_information <- function(dir_out, cores=NULL) {
     # register cores for parallel computation
     if (is.null(cores)) {
+        message("No number of cores were specified - using all possible.")
         cores <- max(1, parallel::detectCores() - 2)
     } else {
+        message(sprintf("Computing mutual information with %s cores"), cores)
         cores <- max(1, cores)
     }
     doParallel::registerDoParallel(cores = cores)

--- a/R/compute_non_self_talk.R
+++ b/R/compute_non_self_talk.R
@@ -47,6 +47,8 @@ compute_non_self_talk_type <- function(ligands, type, letter, dir_in, dir_out) {
     if (is.null(cores)) {
         message("No number of cores were specified - using all possible.")
         cores <- max(1, parallel::detectCores() - 2)
+    } else {
+        message(sprintf("Computing with %s cores"), cores)
     }
     
     doParallel::registerDoParallel(cores = cores)

--- a/R/compute_non_self_talk.R
+++ b/R/compute_non_self_talk.R
@@ -44,7 +44,11 @@ compute_non_self_talk_type <- function(ligands, type, letter, dir_in, dir_out) {
     ligands_valid <- ligands[valid,]
 
     # detect and register cores
-    cores <- max(1, parallel::detectCores() - 2)
+    if (is.null(cores)) {
+        message("No number of cores were specified - using all possible.")
+        cores <- max(1, parallel::detectCores() - 2)
+    }
+    
     doParallel::registerDoParallel(cores = cores)
 
     # parallel loop for MI distances

--- a/R/compute_non_self_talk.R
+++ b/R/compute_non_self_talk.R
@@ -5,7 +5,9 @@ noise <- function(n) {
 }
 
 #' @noRd
-compute_non_self_talk_type <- function(ligands, type, letter, dir_in, dir_out) {
+compute_non_self_talk_type <- function(
+    ligands, type, letter, dir_in, dir_out, cores=NULL
+    ) {
     # format filename, join to full path
     fpath_scrna <- file.path(dir_in, sprintf("scRNAseq_%s.csv", type))
     fpath_out <- file.path(dir_out, sprintf("NonSelfTalkSco_Typ%s.txt", letter))
@@ -48,7 +50,7 @@ compute_non_self_talk_type <- function(ligands, type, letter, dir_in, dir_out) {
         message("No number of cores were specified - using all possible.")
         cores <- max(1, parallel::detectCores() - 2)
     } else {
-        message(sprintf("Computing with %s cores"), cores)
+        message(sprintf("Computing with %s cores", cores))
     }
     
     doParallel::registerDoParallel(cores = cores)
@@ -106,8 +108,10 @@ compute_non_self_talk_type <- function(ligands, type, letter, dir_in, dir_out) {
 #' @param dir_out Output directory
 #' @return None
 #' @export
-compute_non_self_talk <- function(ligands, type_a, type_b, dir_in, dir_out) {
-    compute_non_self_talk_type(ligands, type_a, "A", dir_in, dir_out)
-    compute_non_self_talk_type(ligands, type_b, "B", dir_in, dir_out)
+compute_non_self_talk <- function(
+    ligands, type_a, type_b, dir_in, dir_out, cores=NULL
+    ) {
+    compute_non_self_talk_type(ligands, type_a, "A", dir_in, dir_out, cores)
+    compute_non_self_talk_type(ligands, type_b, "B", dir_in, dir_out, cores)
     NULL
 }

--- a/R/cytotalk.R
+++ b/R/cytotalk.R
@@ -140,7 +140,7 @@ run_cytotalk <- function(
     # compute preferential expression measure
     tick(1, "Preprocessing...")
     preprocess(proteins, type_a, type_b, cutoff_a, cutoff_b, dir_in, dir_out)
-    compute_non_self_talk(ligands, type_a, type_b, dir_in, dir_out)
+    compute_non_self_talk(ligands, type_a, type_b, dir_in, dir_out, cores)
     compute_pem(dir_in, dir_out)
 
     # compute mutual information (within types)
@@ -162,7 +162,7 @@ run_cytotalk <- function(
 
     # run Kolmogorov-Smirnov tests
     tick(6, "Determine best signaling network...")
-    generate_signaling_network(dir_out)
+    generate_signaling_network(dir_out, cores)
 
     # generate SIF and SVG files
     tick(7, "Generate network output...")

--- a/R/cytotalk.R
+++ b/R/cytotalk.R
@@ -113,7 +113,7 @@ run_cytotalk <- function(
     ligands=CytoTalk::ligands_human,
     cutoff_a=0.1, cutoff_b=0.1,
     beta_max=100, omega_min=0.5, omega_max=0.5,
-    depth=3) {
+    depth=3, cores=NULL) {
 
     # must have valid data directory
     type_names <- check_valid_names(dir_in)

--- a/R/generate_signaling_network.R
+++ b/R/generate_signaling_network.R
@@ -36,7 +36,7 @@ generate_summary <- function(dir_out) {
 }
 
 #' @noRd
-compute_kolmogorov_smirnov <- function(dir_out) {
+compute_kolmogorov_smirnov <- function(dir_out, cores=NULL) {
     # format filepaths
     fpath_edge <- file.path(dir_out, "PCSF_EdgeOccurance.txt")
     fpath_pval <- file.path(dir_out, "PCSF_EdgeTestValues.txt")
@@ -68,7 +68,7 @@ compute_kolmogorov_smirnov <- function(dir_out) {
         message("No number of cores were specified - using all possible.")
         cores <- max(1, parallel::detectCores() - 2)
     } else {
-        message(sprintf("Computing K-S tests with %s cores"), cores)
+        message(sprintf("Computing K-S tests with %s cores", cores))
     }
     
     doParallel::registerDoParallel(cores = cores)
@@ -111,8 +111,8 @@ compute_kolmogorov_smirnov <- function(dir_out) {
 #' @param dir_out Output directory
 #' @return None
 #' @export
-generate_signaling_network <- function(dir_out) {
+generate_signaling_network <- function(dir_out, cores=NULL) {
     generate_summary(dir_out)
-    compute_kolmogorov_smirnov(dir_out)
+    compute_kolmogorov_smirnov(dir_out, cores)
     NULL
 }

--- a/R/generate_signaling_network.R
+++ b/R/generate_signaling_network.R
@@ -67,6 +67,8 @@ compute_kolmogorov_smirnov <- function(dir_out) {
     if (is.null(cores)) {
         message("No number of cores were specified - using all possible.")
         cores <- max(1, parallel::detectCores() - 2)
+    } else {
+        message(sprintf("Computing K-S tests with %s cores"), cores)
     }
     
     doParallel::registerDoParallel(cores = cores)

--- a/R/generate_signaling_network.R
+++ b/R/generate_signaling_network.R
@@ -64,7 +64,11 @@ compute_kolmogorov_smirnov <- function(dir_out) {
     lst_counts <- tapply(vec_counts, vec_param, c)
 
     # detect and register cores
-    cores <- max(1, parallel::detectCores() - 2)
+    if (is.null(cores)) {
+        message("No number of cores were specified - using all possible.")
+        cores <- max(1, parallel::detectCores() - 2)
+    }
+    
     doParallel::registerDoParallel(cores = cores)
 
     # parallel loop for Kolmogorov-Smirnov test

--- a/R/integrate_gene_network.R
+++ b/R/integrate_gene_network.R
@@ -381,7 +381,7 @@ write_integrated_net <- function(dir_out) {
     fpath_node_b <- file.path(dir_out, "GeneNodePrizeB.txt")
     fpath_edge_a <- file.path(dir_out, "MI_TypA.txt")
     fpath_edge_b <- file.path(dir_out, "MI_TypB.txt")
-    fpath_edge_ct <- file.path(dir_out, "CrossTalk_TypATypB.txt")
+    fpath_edge_ct <- file.path(dir_out, "Crosstalk_TypATypB.txt")
     fpath_out <- file.path(dir_out, "IntegratedNetwork.cfg")
 
     # stop if input file doesn't exist,


### PR DESCRIPTION
There is a typo in the file name requested by `write_integrated_net` which crashes CytoTalk.